### PR TITLE
Removes changes to .bashrc included upon install

### DIFF
--- a/debian/prerm
+++ b/debian/prerm
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+kinect2rm

--- a/root/usr/sbin/kinect2rm
+++ b/root/usr/sbin/kinect2rm
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+sed -i '/source ~\/kinect_ws\/devel\/setup.bash/d' ~/.bashrc
+sed -i '/export ROS_MASTER_URI=http:\/\/c1:11311/d' ~/.bashrc
+sed -i '/export ROS_IP=10.68.0.10/d' ~/.bashrc
+. ~/.bashrc


### PR DESCRIPTION
When not included, a ton of extra lines remained in the .bashrc after removal of the package.