### PR TITLE
Removed clear from install script

### DIFF
--- a/root/usr/sbin/kinect2setup
+++ b/root/usr/sbin/kinect2setup
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-clear
 echo "Kinect Driver and ROS Installion"
 echo "The following script will install:
 	beignet


### PR DESCRIPTION
Makes it easier to see output from preinst script, including whether it succeeded or failed and whether install will continue.