### PR TITLE
changed location of kinect dev rule

### DIFF
--- a/root/usr/sbin/kinect2setup
+++ b/root/usr/sbin/kinect2setup
@@ -38,7 +38,7 @@ fi
 
 # Make UDEV rules for Kinect
 cd
-sudo cp libfreenect2/rules/90-kinect2.rules /etc/udev/rules.d/
+sudo cp libfreenect2/platform/linux/udev/90-kinect2.rules /etc/udev/rules.d/
 
 # Install Iai_kinect2
 if [ ! -d "kinect_ws" ];


### PR DESCRIPTION
It would appear that the location of the kinect udev rule has changed in the current version of libfreenect2.  This change corrects the location of the file.